### PR TITLE
Allow incoming connections to the TailGuard host

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ hosts, advertise itself as an exit node, and authenticate with the given
 authkey.
 
 Supported configuration parameters through environment:
+- `TG_EXPOSE_HOST` - Set to 1 if you want to allow connections from TS and WG hosts
 - `WG_DEVICE` - WireGuard device name, must be valid and match config file name (**default:** wg0)
 - `TS_DEVICE` - Tailscale device name, must be a valid device name (**default:** tailscale0)
 - `TS_PORT` - Tailscale port number, should be exposed by Docker (**default:** 41641)

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -70,6 +70,10 @@ iptables -P INPUT DROP
 # Create a chain for TailGuard input, dropping incoming connections
 # This is only for TS_DEVICE, which Tailscale accepts by default
 iptables -N tg-input
+if [ $TG_EXPOSE_HOST -eq 1 ]; then
+  iptables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
+  iptables -A tg-input -i "${WG_DEVICE}" -j ACCEPT
+fi
 iptables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
 iptables -A tg-input -i "${TS_DEVICE}" -j DROP
 
@@ -97,6 +101,10 @@ ip6tables -P INPUT DROP
 # Create a chain for TailGuard input, dropping incoming connections
 # This is only for TS_DEVICE, which Tailscale accepts by default
 ip6tables -N tg-input
+if [ $TG_EXPOSE_HOST -eq 1 ]; then
+  ip6tables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
+  ip6tables -A tg-input -i "${WG_DEVICE}" -j ACCEPT
+fi
 ip6tables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
 ip6tables -A tg-input -i "${TS_DEVICE}" -j DROP
 

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -70,7 +70,7 @@ iptables -P INPUT DROP
 # Create a chain for TailGuard input, dropping incoming connections
 # This is only for TS_DEVICE, which Tailscale accepts by default
 iptables -N tg-input
-if [ $TG_EXPOSE_HOST -eq 1 ]; then
+if [ ${TG_EXPOSE_HOST:-0} -eq 1 ]; then
   echo "Expose host to Tailscale and WireGuard networks over IPv4"
   iptables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
   iptables -A tg-input -i "${WG_DEVICE}" -j ACCEPT
@@ -103,7 +103,7 @@ ip6tables -P INPUT DROP
 # Create a chain for TailGuard input, dropping incoming connections
 # This is only for TS_DEVICE, which Tailscale accepts by default
 ip6tables -N tg-input
-if [ $TG_EXPOSE_HOST -eq 1 ]; then
+if [ ${TG_EXPOSE_HOST:-0} -eq 1 ]; then
   echo "Expose host to Tailscale and WireGuard networks over IPv6"
   ip6tables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
   ip6tables -A tg-input -i "${WG_DEVICE}" -j ACCEPT

--- a/bin/entrypoint.sh
+++ b/bin/entrypoint.sh
@@ -71,11 +71,13 @@ iptables -P INPUT DROP
 # This is only for TS_DEVICE, which Tailscale accepts by default
 iptables -N tg-input
 if [ $TG_EXPOSE_HOST -eq 1 ]; then
+  echo "Expose host to Tailscale and WireGuard networks over IPv4"
   iptables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
   iptables -A tg-input -i "${WG_DEVICE}" -j ACCEPT
+else
+  iptables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
+  iptables -A tg-input -i "${TS_DEVICE}" -j DROP
 fi
-iptables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
-iptables -A tg-input -i "${TS_DEVICE}" -j DROP
 
 # Create a chain for TailGuard forward, drop external destinations
 iptables -P FORWARD DROP
@@ -102,11 +104,13 @@ ip6tables -P INPUT DROP
 # This is only for TS_DEVICE, which Tailscale accepts by default
 ip6tables -N tg-input
 if [ $TG_EXPOSE_HOST -eq 1 ]; then
+  echo "Expose host to Tailscale and WireGuard networks over IPv6"
   ip6tables -A tg-input -i "${TS_DEVICE}" -j ACCEPT
   ip6tables -A tg-input -i "${WG_DEVICE}" -j ACCEPT
+else
+  ip6tables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
+  ip6tables -A tg-input -i "${TS_DEVICE}" -j DROP
 fi
-ip6tables -A tg-input -i "${TS_DEVICE}" -m state --state ESTABLISHED,RELATED -j ACCEPT
-ip6tables -A tg-input -i "${TS_DEVICE}" -j DROP
 
 # Create a chain for TailGuard forward, drop external destinations
 ip6tables -P FORWARD DROP


### PR DESCRIPTION
In some cases the user might want to run a sidecar on the TailGuard host and connect to it through both Tailnet and WireGuard.

An attempt to implement a feature request in https://github.com/juhovh/tailguard/issues/1